### PR TITLE
Trace baseAssignment flow for sim card count

### DIFF
--- a/baseAssignment_Flow_Analysis.md
+++ b/baseAssignment_Flow_Analysis.md
@@ -1,0 +1,314 @@
+# Base Assignment Flow Analysis in QueueCustomerOptimization Lambda
+
+## Overview
+This document provides a comprehensive analysis of the `baseAssignment` method flow within the `ProcessPlanNameGroup` method in the `QueueCustomerOptimization` lambda. The flow is critical for determining how `baseAssignedSimCardCount` is assigned and used in the optimization process.
+
+## 1. Entry Point: ProcessPlanNameGroup Method
+
+### Location
+- **File**: `AltaworxSimCardCostQueueCustomerOptimization.cs`
+- **Method**: `ProcessPlanNameGroup` (Line 566)
+- **Lambda**: QueueCustomerOptimization
+
+### Method Signature
+```csharp
+private async Task<bool> ProcessPlanNameGroup(
+    KeySysLambdaContext context, 
+    int? integrationAuthenticationId, 
+    bool usesProration, 
+    string revAccountNumber, 
+    int? AMOPCustomerId, 
+    BillingPeriod billingPeriod, 
+    long instanceId, 
+    OptimizationChargeType chargeType, 
+    IGrouping<string, RatePlan> planNameGroup, 
+    List<vwOptimizationSimCard> optimizationSimCards)
+```
+
+## 2. Context Within ProcessPlanNameGroup
+
+The `baseAssignedSimCardsCount` assignment occurs within a nested loop structure:
+
+### Outer Loop (Line 568)
+Groups rate plans by `AllowsSimPooling` property:
+```csharp
+foreach (var ratePlanGroup in planNameGroup.GroupBy(x => x.AllowsSimPooling))
+```
+
+### Rate Plan Validation (Lines 573-579)
+- Retrieves rate plans for the group
+- Validates that rate plans don't have zero values for `DataPerOverageCharge` or `OverageRate`
+- Returns `true` (error) if zero values found
+
+### Device Count Check (Lines 582-588)
+- Continues if no optimization SIM cards remain for processing
+- Logs informational message about no devices to optimize
+
+## 3. Base Assignment Call (Line 595)
+
+### Complete Call Structure
+```csharp
+var baseAssignedSimCardsCount = BaseDeviceAssignment(
+    context, 
+    instanceId, 
+    commPlanGroupId, 
+    billingPeriod.ServiceProviderId,
+    revAccountNumber, 
+    integrationAuthenticationId, 
+    null, 
+    ratePoolCollection, 
+    ratePools, 
+    optimizationSimCards, 
+    billingPeriod, 
+    usesProration, 
+    AMOPCustomerId
+);
+```
+
+### Prerequisites
+Before the call, several setup operations occur:
+
+1. **Comm Plan Group Creation** (Line 590):
+   ```csharp
+   var commPlanGroupId = CreateCommPlanGroup(context, instanceId);
+   ```
+
+2. **Rate Pool Calculations** (Line 591):
+   ```csharp
+   var calculatedPlans = RatePoolCalculator.CalculateMaxAvgUsage(groupRatePlans, null);
+   ```
+
+3. **Rate Pool Factory Operations** (Line 592):
+   ```csharp
+   var ratePools = RatePoolFactory.CreateRatePools(calculatedPlans, billingPeriod, usesProration, chargeType);
+   ```
+
+4. **Rate Pool Collection Creation** (Line 593):
+   ```csharp
+   var ratePoolCollection = RatePoolCollectionFactory.CreateRatePoolCollection(ratePools);
+   ```
+
+## 4. BaseDeviceAssignment Method Implementation
+
+### Location
+- **File**: `AWSFunctionBase.cs`
+- **Method**: `BaseDeviceAssignment` (Line 2024)
+
+### Method Signature
+```csharp
+public int BaseDeviceAssignment(
+    KeySysLambdaContext context, 
+    long instanceId, 
+    long commPlanGroupId, 
+    int? serviceProviderId,
+    string revAccountNumber, 
+    int? integrationAuthenticationId, 
+    List<string> commPlanNames, 
+    RatePoolCollection ratePoolCollection,
+    List<M2MRatePool> ratePools, 
+    List<vwOptimizationSimCard> providerSimList, 
+    BillingPeriod billingPeriod, 
+    bool usesProration, 
+    int? AMOPCustomerId = null, 
+    bool shouldFilterByRatePlanType = false)
+```
+
+### Step-by-Step Flow in BaseDeviceAssignment
+
+#### Step 1: Queue Creation (Line 2029)
+```csharp
+var queueId = CreateQueue(context, instanceId, commPlanGroupId, serviceProviderId, usesProration);
+```
+
+#### Step 2: SIM Card Filtering (Lines 2031-2040)
+- Creates a copy of provider SIM list
+- If customer-specific (revAccountNumber or AMOPCustomerId exists):
+  - Extracts customer rate plan codes from rate pool collection
+  - Filters SIM cards to only include those matching customer rate plan codes
+
+#### Step 3: Queue Start (Line 2042)
+```csharp
+StartQueue(context, queueId, string.Empty);
+```
+
+#### Step 4: Data Usage Projection (Line 2044)
+```csharp
+var simCards = ProjectDataUsageAndSaveDeviceByPortalType(
+    context, 
+    billingPeriod, 
+    instanceId, 
+    simList, 
+    autoChangeRatePlan: true, 
+    commPlanGroupId);
+```
+
+#### Step 5: Redis Cache Handling (Lines 2047-2051)
+- Tests Redis connection
+- If available, saves device data to cache for faster optimizer lambda queries
+
+#### Step 6: Rate Pool Assigner Creation (Lines 2053-2056)
+```csharp
+var assigner = new RatePoolAssigner(
+    string.Empty, 
+    ratePoolCollection, 
+    simCards, 
+    context.LambdaContext, 
+    isUsingRedisCache,
+    PortalType,
+    shouldFilterByRatePlanType,
+    ratePoolCollection.ShouldPoolByOptimizationGroup);
+```
+
+#### Step 7: Core Base Assignment Logic (Line 2057)
+```csharp
+assigner.BaseAssignmentOfSimCards(ratePools, queueId);
+```
+
+**Critical Note**: This is where the actual SIM card assignment logic occurs, but the `RatePoolAssigner` class implementation is not visible in the current codebase files.
+
+#### Step 8: Result Processing (Lines 2059-2072)
+```csharp
+// Record results
+assigner.SetPortalTypeToBestResult(PortalType);
+var result = assigner.Best_Result;
+var totalCost = result.CombinedRatePools.TotalDataCost;
+
+// Base device assignment
+if (AMOPCustomerId == null)
+{
+    RecordResults(context, queueId, revAccountNumber, result);
+}
+else
+{
+    RecordResults(context, queueId, AMOPCustomerId.GetValueOrDefault(0), result);
+}
+```
+
+#### Step 9: Queue Cleanup (Line 2075)
+```csharp
+StopQueue(context, queueId);
+```
+
+#### Step 10: Return Value (Line 2078)
+```csharp
+return result.CombinedRatePools.TotalSimCardCount;
+```
+
+## 5. baseAssignedSimCardCount Assignment and Usage
+
+### Assignment
+The returned value from `BaseDeviceAssignment` is assigned to `baseAssignedSimCardsCount`:
+```csharp
+var baseAssignedSimCardsCount = BaseDeviceAssignment(...);
+```
+
+### Critical Usage Check (Lines 603-621)
+```csharp
+if (baseAssignedSimCardsCount > OptimizationConstant.BaseAssignedDeviceLimit)
+{
+    // Permute rate plans logic
+    if (calculatedPlans.Count > OptimizationConstant.RatePlanLimit)
+    {
+        LogInfo(context, LogTypeConstant.Exception, 
+            $"The rate plan count exceeds the limit of 15 for this Rate Plan Code {ratePlanGroup.Key}");
+        continue;
+    }
+    if (calculatedPlans.Count <= OptimizationConstant.RatePlanMinimumLimit)
+    {
+        LogInfo(context, CommonConstants.INFO, 
+            string.Format(LogCommonStrings.AUTO_CHANGE_MINIMUM_RATE_PLAN_LIMIT_REACHED, 
+            calculatedPlans.Count, planNameGroup.Key, ratePlanGroup.Key));
+        continue;
+    }
+    GeneratePermutationQueueRatePlans(context, usesProration, billingPeriod, 
+        instanceId, commPlanGroupId, ratePoolCollection, commGroupRatePlanTable);
+
+    // Enqueue rate plan permutations
+    await EnqueueOptimizationRunsAsync(context, instanceId, 
+        new List<long>() { commPlanGroupId }, chargeType, QueuesPerInstance, 
+        skipLowerCostCheck: true, isCustomerOptimization: true);
+}
+else
+{
+    LogInfo(context, LogTypeConstant.Info, 
+        $"Plan name group for the rate plans {string.Join(',', ratePlanGroup.Select(plan => plan.Id).ToList())} only have {baseAssignedSimCardsCount} devices. The optimization by permutation logic will not be triggered.");
+}
+```
+
+## 6. Key Business Logic
+
+### Purpose of baseAssignedSimCardCount
+The `baseAssignedSimCardCount` represents the total number of SIM cards that were successfully assigned to rate pools during the base assignment process.
+
+### Decision Point
+- **If > OptimizationConstant.BaseAssignedDeviceLimit**: Triggers complex optimization logic with rate plan permutations
+- **If ≤ OptimizationConstant.BaseAssignedDeviceLimit**: Skips permutation optimization as insufficient devices for meaningful optimization
+
+### Rate Plan Permutation Logic
+When triggered, the system:
+1. Validates rate plan count limits
+2. Generates rate pool sequences/permutations
+3. Enqueues optimization runs for parallel processing
+
+## 7. Data Flow Summary
+
+```
+ProcessPlanNameGroup
+    ↓
+Rate Plan Grouping (by AllowsSimPooling)
+    ↓
+Setup Operations (CommPlanGroup, Calculations, RatePools)
+    ↓
+BaseDeviceAssignment Call
+    ↓
+Queue Creation & SIM Filtering
+    ↓
+Data Usage Projection & Cache Handling
+    ↓
+RatePoolAssigner Creation
+    ↓
+BaseAssignmentOfSimCards (External Logic)
+    ↓
+Result Processing & Recording
+    ↓
+Return TotalSimCardCount
+    ↓
+baseAssignedSimCardsCount Assignment
+    ↓
+Business Logic Decision (Optimization vs Skip)
+```
+
+## 8. External Dependencies
+
+### Missing Implementation Details
+- **RatePoolAssigner.BaseAssignmentOfSimCards**: Core assignment logic not visible in codebase
+- **Best_Result.CombinedRatePools.TotalSimCardCount**: Property structure not fully documented
+- **OptimizationConstant.BaseAssignedDeviceLimit**: Threshold value not specified
+
+### Key Classes/Interfaces
+- `RatePoolAssigner`: Main assignment orchestrator
+- `RatePoolCollection`: Container for rate pools
+- `M2MRatePool`: Individual rate pool representation
+- `vwOptimizationSimCard`: SIM card data structure
+- `BillingPeriod`: Billing period context
+
+## 9. Performance Considerations
+
+### Redis Caching
+- Conditional caching improves performance for subsequent optimizer lambda calls
+- Cache availability tested before usage
+
+### Parallel Processing
+- Rate plan permutations enqueued for parallel execution
+- Queue-based architecture supports distributed processing
+
+## 10. Error Handling
+
+### Zero Value Validation
+Rate plans with zero `DataPerOverageCharge` or `OverageRate` cause method to return error state.
+
+### Rate Plan Limits
+- Maximum 15 rate plans per rate plan code
+- Minimum rate plan requirements for optimization triggering
+
+This analysis provides the complete flow of how `baseAssignedSimCardCount` is determined and utilized within the QueueCustomerOptimization lambda's ProcessPlanNameGroup method.


### PR DESCRIPTION
Add documentation for the `baseAssignment` method flow to explain how `baseAssignedSimCardCount` is determined and used.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bd07bb2-9974-4f53-a7ef-591fda42a03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bd07bb2-9974-4f53-a7ef-591fda42a03a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

